### PR TITLE
Add store info placeholder in footer

### DIFF
--- a/framework/class-theme-manager.php
+++ b/framework/class-theme-manager.php
@@ -817,6 +817,48 @@ class Theme_Manager
         return $locations;
     }
 
+    /**
+     * Retrieve WooCommerce store details or return placeholder information.
+     *
+     * @return array
+     */
+    public function get_store_information()
+    {
+        $store = [];
+
+        $store['name'] = get_bloginfo('name');
+
+        $address_parts   = [];
+        $address_1       = get_option('woocommerce_store_address');
+        $address_2       = get_option('woocommerce_store_address_2');
+        $city            = get_option('woocommerce_store_city');
+        $state           = get_option('woocommerce_store_state');
+        $postcode        = get_option('woocommerce_store_postcode');
+
+        if ($address_1) {
+            $address_parts[] = $address_1;
+        }
+        if ($address_2) {
+            $address_parts[] = $address_2;
+        }
+
+        $city_line = trim("$city $state $postcode");
+        if ($city_line) {
+            $address_parts[] = $city_line;
+        }
+
+        $store['address'] = $address_parts ? implode(', ', $address_parts) : '1234 Placeholder St, City, ST 00000';
+
+        $store['phone'] = get_option('woocommerce_store_phone');
+        if (!$store['phone']) {
+            $store['phone'] = '5555555555';
+        }
+
+        $store['hours'] = 'Mon - Fri: 9am - 5pm';
+
+        return $store;
+    }
+
     public function get_social_network_url($social_network)
     {
         return $this->get_theme_option($social_network);

--- a/styles/dist/main.css
+++ b/styles/dist/main.css
@@ -6352,6 +6352,12 @@ button {
     font-size: 14px
 }
 
+.footer__business-info {
+    font-size: 14px;
+    margin-left: 16px;
+    text-align: right
+}
+
 .footer__payments img {
     display: inline-block
 }
@@ -6450,6 +6456,10 @@ button {
 
     .footer__legal span {
         margin-top: 15px
+    }
+    .footer__business-info {
+        margin-top: 15px;
+        text-align: center
     }
 }
 

--- a/template-parts/footer/main-footer.php
+++ b/template-parts/footer/main-footer.php
@@ -69,6 +69,13 @@
     
     </div>
     <div class="footer__legal">
+      <div class="footer__business-info">
+        <?php $store = Theme_Manager::get_instance()->get_store_information(); ?>
+        <strong><?php echo esc_html($store['name']); ?></strong><br>
+        <span><?php echo esc_html($store['address']); ?></span><br>
+        <span><?php echo Theme_Manager::get_instance()->format_phone($store['phone']); ?></span><br>
+        <span><?php echo esc_html($store['hours']); ?></span>
+      </div>
       <div class="footer__payments">
         <img src="<?php Theme_Manager::get_instance()->get_image_assets('i-visa.png'); ?>" alt="">
         <img src="<?php Theme_Manager::get_instance()->get_image_assets('i-mastercard.png'); ?>" alt="">


### PR DESCRIPTION
## Summary
- show WooCommerce store information (with placeholders) in footer
- style footer store info

## Testing
- `npm test` *(fails: package.json missing)*